### PR TITLE
Test failure with SupervisorAgentIT#agents_system_test

### DIFF
--- a/langchain4j-agentic/src/test/java/dev/langchain4j/agentic/SupervisorAgentIT.java
+++ b/langchain4j-agentic/src/test/java/dev/langchain4j/agentic/SupervisorAgentIT.java
@@ -62,7 +62,7 @@ public class SupervisorAgentIT {
             The user request is: '{{it}}'.
             """)
         @Agent("An agent that categorizes the user request")
-        String categorizeRequest(String request);
+        String categorizeRequest(@P("it") String request);
     }
 
     @Test


### PR DESCRIPTION
`mvn verify -Dit.test=SupervisorAgentIT#agents_system_test` fails with
```
[INFO] Running dev.langchain4j.agentic.SupervisorAgentIT
[ERROR] Tests run: 1, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 0.163 s <<< FAILURE! -- in dev.langchain4j.agentic.SupervisorAgentIT
[ERROR] dev.langchain4j.agentic.SupervisorAgentIT.agents_system_test -- Time elapsed: 0.149 s <<< ERROR!
java.lang.IllegalArgumentException: Parameter name not specified and no @P or @V annotation present: java.lang.String arg0
	at dev.langchain4j.agentic.internal.AgentSpecification.lambda$parameterName$0(AgentSpecification.java:50)
	at java.base/java.util.Optional.orElseThrow(Optional.java:403)
	at dev.langchain4j.agentic.internal.AgentSpecification.parameterName(AgentSpecification.java:50)
	at dev.langchain4j.agentic.internal.AgentUtil.parameterName(AgentUtil.java:87)
	at dev.langchain4j.agentic.internal.AgentUtil.lambda$argumentsFromMethod$3(AgentUtil.java:76)
	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197)
	at java.base/java.util.Spliterators$ArraySpliterator.forEachRemaining(Spliterators.java:992)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:575)
	at java.base/java.util.stream.AbstractPipeline.evaluateToArrayNode(AbstractPipeline.java:260)
	at java.base/java.util.stream.ReferencePipeline.toArray(ReferencePipeline.java:616)
	at java.base/java.util.stream.ReferencePipeline.toArray(ReferencePipeline.java:622)
	at java.base/java.util.stream.ReferencePipeline.toList(ReferencePipeline.java:627)
	at dev.langchain4j.agentic.internal.AgentUtil.argumentsFromMethod(AgentUtil.java:77)
	at dev.langchain4j.agentic.internal.AgentSpecification.fromMethodAndSpec(AgentSpecification.java:45)
	at dev.langchain4j.agentic.internal.AgentSpecification.fromMethod(AgentSpecification.java:37)
	at dev.langchain4j.agentic.internal.AgentUtil.lambda$methodToAgentExecutor$2(AgentUtil.java:67)
	at java.base/java.util.Optional.map(Optional.java:260)
	at dev.langchain4j.agentic.internal.AgentUtil.methodToAgentExecutor(AgentUtil.java:67)
	at dev.langchain4j.agentic.internal.AgentUtil.agentToExecutor(AgentUtil.java:46)
	at dev.langchain4j.agentic.internal.AgentUtil.agentToExecutor(AgentUtil.java:30)
	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197)
	at java.base/java.util.Spliterators$ArraySpliterator.forEachRemaining(Spliterators.java:992)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:575)
	at java.base/java.util.stream.AbstractPipeline.evaluateToArrayNode(AbstractPipeline.java:260)
	at java.base/java.util.stream.ReferencePipeline.toArray(ReferencePipeline.java:616)
	at java.base/java.util.stream.ReferencePipeline.toArray(ReferencePipeline.java:622)
	at java.base/java.util.stream.ReferencePipeline.toList(ReferencePipeline.java:627)
	at dev.langchain4j.agentic.internal.AgentUtil.agentsToExecutors(AgentUtil.java:25)
	at dev.langchain4j.agentic.internal.AbstractService.subAgents(AbstractService.java:41)
	at dev.langchain4j.agentic.supervisor.SupervisorAgentServiceImpl.subAgents(SupervisorAgentServiceImpl.java:23)
	at dev.langchain4j.agentic.SupervisorAgentIT.agents_system_test(SupervisorAgentIT.java:87)
```

This PR is not really a fix, but rather a workaround. Just to illustrate the issue.

Probably you would want to fix AgentUtil by checking that the argument is only one and give the default name `it`.

Feel free to close this PR when you fix the issue on your side.